### PR TITLE
Moved readLine to correct interface

### DIFF
--- a/src/language-tools-and-standard-library/standard-library-api/console.md
+++ b/src/language-tools-and-standard-library/standard-library-api/console.md
@@ -22,7 +22,6 @@ Interface documentation:
 | Operation Name                    | Input Type                        | Output Type | Faults |
 |:----------------------------------|:----------------------------------|:------------|:-------|
 | [in](console.md#in)               | [InRequest](console.md#InRequest) | -           |        |
-| [readLine](console.md#readLine)   | -                                 | string      |        |
 
 ## Operation Description
 
@@ -50,28 +49,6 @@ type InRequest: string {
 
 * `token : string`
 
-### readLine <a id="readLine"></a>
-
-Operation documentation:
-
-Invocation template:
-
-```jolie
-readLine@Console()( input )
-```
-
-#### Request type
-
-Type: -
-
-`void : any`
-
-#### Response type
-
-Type: string
-
-`string : any`
-
 ### ConsoleInterface <a id="ConsoleInterface"></a>
 
 Interface documentation:
@@ -84,6 +61,7 @@ Interface documentation:
 | [unsubscribeSessionListener](console.md#unsubscribeSessionListener) | [UnsubscribeSessionListener](console.md#UnsubscribeSessionListener) | void        |        |
 | [subscribeSessionListener](console.md#subscribeSessionListener)     | [SubscribeSessionListener](console.md#SubscribeSessionListener)     | void        |        |
 | [enableTimestamp](console.md#enableTimestamp)                       | [EnableTimestampRequest](console.md#EnableTimestampRequest)         | void        |        |
+| [readLine](console.md#readLine)                                     | [ReadLineRequest](console.md#ReadLineRequest)                       | string      |        |
 
 ## Operation Description
 
@@ -251,3 +229,29 @@ Type: void
 
 `void : void`
 
+### readLine <a id="readLine"></a>
+
+Operation documentation: Read a line from the console using a synchronous call
+
+Invocation template:
+
+```jolie
+readLine@Console( request )( response )
+```
+
+#### Request type
+
+Type: ReadLineRequest
+```jolie
+type ReadLineRequest: void {
+	secret?: bool
+}
+```
+
+`ReadLineRequest : void`
+* `secret: bool`
+#### Response type
+
+Type: string
+
+`string : string`


### PR DESCRIPTION
Moved the readLine operation into the correct interface as seen by the source `console.iol` file: (https://github.com/jolie/jolie/blob/3cfb780a65282e2dac4e08c8e4c9db4ab022f777/include/console.iol#L4)

Also specified the types of the request :D
